### PR TITLE
Change workflow trigger to 'main' branch

### DIFF
--- a/.github/workflows/release-pipline.yml
+++ b/.github/workflows/release-pipline.yml
@@ -8,11 +8,11 @@ permissions:
   pull-requests: write
   statuses: write
 
-# Trigger the workflow on push to the development branch
+# Trigger the workflow on push to the main branch
 on:
   push:
     branches:
-      - development
+      - main
 
 # Set environment variables
 env:


### PR DESCRIPTION
Updated the `release-pipeline.yml` file to trigger the workflow on pushes to the 'main' branch instead of the 'development' branch. This change ensures that the workflow runs when there are updates to the 'main' branch.