### PR TITLE
Resolve #32

### DIFF
--- a/src/G4.Services.Hub/wwwroot/js/g4-client.js
+++ b/src/G4.Services.Hub/wwwroot/js/g4-client.js
@@ -867,7 +867,10 @@ class G4Client {
 		};
 
 		// Extract the authentication parameters from the definition properties.
-		const authentication = definition.properties["authentication"];
+		const authentication = definition.properties?.authentication;
+
+        // Extract the data source from the definition properties.
+        const dataSource = definition.properties?.dataSource;
 
         // Extract the driver parameters if both driver and driverBinaries are provided.
 		let driverParameters = getDriverParameters(definition.properties?.driverParameters);
@@ -939,8 +942,11 @@ class G4Client {
 
 		// Return a newly constructed automation object containing all relevant data.
 		return {
-			// Store any authentication details passed in.
+            // Include the authentication details in the automation object.
 			authentication,
+
+            // Include the data source details in the automation object.
+			dataSource,
 
 			// Include optional driver parameters (e.g., session data).
 			driverParameters,


### PR DESCRIPTION
Use optional chaining for safer property access

Updated property access in `definition.properties` to use optional chaining (`?.`) for `authentication` and `dataSource`, preventing potential runtime errors. Enhanced comments to clarify the inclusion of these properties in the returned automation object, improving code readability and maintainability.