### PR TITLE
Resolve #36

### DIFF
--- a/src/G4.Services.Hub/wwwroot/js/custom-fields.js
+++ b/src/G4.Services.Hub/wwwroot/js/custom-fields.js
@@ -2992,7 +2992,7 @@ class CustomFields {
          * Validate and sanitize the initial value.
          * If the initial value is not provided, is NaN, or is undefined, default it to `false`.
          */
-        options.initialValue = (!options.initialValue || isNaN(options.initialValue) || options.initialValue === undefined)
+        options.initialValue = (!options.initialValue || options.initialValue === null || Number.isNaN(options.initialValue) || options.initialValue === undefined)
             ? false
             : options.initialValue;
 


### PR DESCRIPTION
Enhance validation for initialValue option

Updated the validation logic for the `initialValue` option to include a check for `null` and utilize `Number.isNaN()` for improved accuracy. This change ensures that if `initialValue` is not provided, is `null`, or is NaN, it defaults to `false`; otherwise, it retains its original value.