### PR TITLE
Update package versions for G4.Api and G4.Plugins

### DIFF
--- a/src/G4.Services.Domain.V4/G4.Services.Domain.V4.csproj
+++ b/src/G4.Services.Domain.V4/G4.Services.Domain.V4.csproj
@@ -19,10 +19,10 @@
 	<!--
 		<PackageReference Include="G4.Api" Version="2025.2.13.29" />
 	-->
-		<PackageReference Include="G4.Api" Version="2025.3.9.33" />
+		<PackageReference Include="G4.Api" Version="2025.3.11.34" />
 		<PackageReference Include="G4.Plugins" Version="2025.3.7.34" />
-		<PackageReference Include="G4.Plugins.Common" Version="2025.3.9.105" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2025.3.9.105" />
+		<PackageReference Include="G4.Plugins.Common" Version="2025.3.11.106" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2025.3.11.106" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.3.1" />
 	</ItemGroup>


### PR DESCRIPTION
Updated `G4.Api` from version `2025.3.9.33` to `2025.3.11.34`. Updated `G4.Plugins.Common` and `G4.Plugins.Ui` from version `2025.3.9.105` to `2025.3.11.106`.