### PR TITLE
Update package references to latest versions

### DIFF
--- a/src/G4.Services.Domain.V4/G4.Services.Domain.V4.csproj
+++ b/src/G4.Services.Domain.V4/G4.Services.Domain.V4.csproj
@@ -19,12 +19,12 @@
 	<!--
 		<PackageReference Include="G4.Api" Version="2025.2.13.29" />
 	-->
-		<PackageReference Include="G4.Api" Version="2025.3.11.34" />
-		<PackageReference Include="G4.Plugins" Version="2025.3.7.34" />
-		<PackageReference Include="G4.Plugins.Common" Version="2025.3.11.106" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2025.3.11.106" />
+		<PackageReference Include="G4.Api" Version="2025.3.29.35" />
+		<PackageReference Include="G4.Plugins" Version="2025.3.28.36" />
+		<PackageReference Include="G4.Plugins.Common" Version="2025.3.28.107" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2025.3.28.107" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.3.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Services.Hub.Api.V4/G4.Services.Hub.Api.V4.csproj
+++ b/src/G4.Services.Hub.Api.V4/G4.Services.Hub.Api.V4.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Services.Hub/G4.Services.Hub.csproj
+++ b/src/G4.Services.Hub/G4.Services.Hub.csproj
@@ -24,7 +24,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Services.Worker/G4.Services.Worker.csproj
+++ b/src/G4.Services.Worker/G4.Services.Worker.csproj
@@ -21,7 +21,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommandBridge" Version="2025.2.26.62" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Settings/G4.Settings.csproj
+++ b/src/G4.Settings/G4.Settings.csproj
@@ -32,7 +32,7 @@
 		<!-- Please refrain from upgrading LiteDB until the locking bug is addressed.
 			 The latest known version without this issue is version 5.0.17. 
 			 https://github.com/mbdavid/LiteDB/issues/1976#issuecomment-1968006775 -->
-		<PackageReference Include="G4.Converters" Version="2025.3.7.34" />
+		<PackageReference Include="G4.Converters" Version="2025.3.28.36" />
 		<PackageReference Include="LiteDB" Version="5.0.17" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />


### PR DESCRIPTION
Upgraded several package references across multiple project files:
- `G4.Api`, `G4.Plugins`, `G4.Plugins.Common`, and `G4.Plugins.Ui` in `G4.Services.Domain.V4.csproj` to newer versions.
- Updated `Swashbuckle.AspNetCore` to version `8.0.0` in `G4.Services.Hub.Api.V4.csproj`, `G4.Services.Hub.csproj`, and `G4.Services.Worker.csproj`.
- Upgraded `G4.Converters` in `G4.Settings.csproj` to version `2025.3.28.36`.