### PR TITLE
Enhance G4 step creation with plugin name

### DIFF
--- a/src/G4.Services.Hub/wwwroot/js/global.js
+++ b/src/G4.Services.Hub/wwwroot/js/global.js
@@ -383,7 +383,7 @@ const setDefinition = (definition) => {
 		const manifest = getManifest(_cache, rule.pluginName);
 
 		// Create a new step using the state machine factory and the retrieved manifest.
-		const step = StateMachineSteps.newG4Step(manifest);
+		const step = StateMachineSteps.newG4Step(manifest, rule.pluginName);
 
 		// Assign the name of the rule's capabilities to the step if available.
 		step.name = step?.pluginName?.toUpperCase() === 'MISSINGPLUGIN'

--- a/src/G4.Services.Hub/wwwroot/js/state-machine.js
+++ b/src/G4.Services.Hub/wwwroot/js/state-machine.js
@@ -226,9 +226,10 @@ class StateMachineSteps {
 	 * Creates a new G4 step based on the provided manifest.
 	 *
 	 * @param {Object} manifest - The manifest object containing properties and parameters.
+	 * @param {string} pluginName - The name of the plugin associated with the step.
 	 * @returns {Object} The newly created G4 step object.
 	 */
-	static newG4Step(manifest) {
+	static newG4Step(manifest, pluginName) {
 		// Creates a new bridge object from a G4 parameter object.
 		const newBridgeObject = (g4ParameterObject) => {
 			let bridgeObject = {
@@ -262,7 +263,7 @@ class StateMachineSteps {
 				context: {},
 				description: "Description not provided.",
 				id: Utilities.newUid(),
-				name: "Missing Plugin",
+				name: Utilities.convertPascalToSpaceCase(pluginName || "Not Available"),
 				parameters: {},
 				pluginName: "MissingPlugin",
 				pluginType: "Action",


### PR DESCRIPTION
Modified `setDefinition` in `global.js` to pass `rule.pluginName` to `StateMachineSteps.newG4Step`, allowing the method to utilize the plugin name. Updated `newG4Step` in `state-machine.js` to accept `pluginName` as a parameter, enhancing step creation. Changed default step name to use `pluginName` in space case, improving clarity.