### PR TITLE
Update .NET SDK version in release pipeline

### DIFF
--- a/.github/workflows/release-pipline.yml
+++ b/.github/workflows/release-pipline.yml
@@ -322,7 +322,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8
+          dotnet-version: 10
 
       - name: Set Version v${{ env.buildVersion }}
         shell: pwsh


### PR DESCRIPTION
The .NET Core SDK version in the `release-pipeline.yml` file has been updated from version `8` to version `10`. This change is applied in the `with` section of the `actions/setup-dotnet@v4` step to ensure compatibility with the latest features and improvements.