### PR TITLE
Update Dockerfiles to .NET 10 SDK and runtime

### DIFF
--- a/docker/G4.Services.Hub.Dockerfile
+++ b/docker/G4.Services.Hub.Dockerfile
@@ -1,5 +1,5 @@
-# Use the official .NET 8 SDK image as the build environment
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+# Use the official .NET 10 SDK image as the build environment
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Set the build configuration (default is Release)
 ARG BUILD_CONFIGURATION=Release
@@ -22,8 +22,8 @@ RUN dotnet build "G4.Services.Hub/G4.Services.Hub.csproj" -c $BUILD_CONFIGURATIO
 # Publish the project
 RUN dotnet publish "G4.Services.Hub/G4.Services.Hub.csproj" -c $BUILD_CONFIGURATION -o /app/publish
 
-# Use the official .NET 8 ASP.NET runtime as the runtime environment
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+# Use the official .NET 10 ASP.NET runtime as the runtime environment
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
 # Set the working directory for the runtime
 WORKDIR /app

--- a/docker/G4.Services.Worker.Dockerfile
+++ b/docker/G4.Services.Worker.Dockerfile
@@ -1,5 +1,5 @@
-# Use the official .NET 8 SDK image as the build environment
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+# Use the official .NET 10 SDK image as the build environment
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 # Set the build configuration (default is Release)
 ARG BUILD_CONFIGURATION=Release
@@ -22,8 +22,8 @@ RUN dotnet build "G4.Services.Worker/G4.Services.Worker.csproj" -c $BUILD_CONFIG
 # Publish the project
 RUN dotnet publish "G4.Services.Worker/G4.Services.Worker.csproj" -c $BUILD_CONFIGURATION -o /app/publish
 
-# Use the official .NET 8 ASP.NET runtime as the runtime environment
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+# Use the official .NET 10 ASP.NET runtime as the runtime environment
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
 # Set the working directory for the runtime
 WORKDIR /app


### PR DESCRIPTION
The Dockerfiles for both `G4.Services.Hub` and `G4.Services.Worker` have been updated to use the .NET 10 SDK and ASP.NET runtime images instead of the .NET 8 versions. This ensures compatibility with .NET 10 features and improvements, updating the base images used for building and running the applications.