### PR TITLE
Comment out 204 status code test in Postman script

### DIFF
--- a/postman/G4.Services.json
+++ b/postman/G4.Services.json
@@ -1748,9 +1748,9 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Status code is 204\", function () {\r",
-									"    pm.response.to.have.status(204);\r",
-									"});"
+									"//pm.test(\"Status code is 204\", function () {\r",
+									"//    pm.response.to.have.status(204);\r",
+									"//});"
 								],
 								"type": "text/javascript",
 								"packages": {}


### PR DESCRIPTION
The test that checks for a 204 response status code has been commented out in the Postman collection script, effectively disabling this validation.