### PR TITLE
Update NuGet packages and improve step naming logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The **G4 Hub API** provides a comprehensive interface for managing templates, en
 The unlimited version of the G4™ Hub API is available for personal or an open source non-profit use, provided it is not deployed in enterprise, governmental, or military environments. To enable full functionality, use the license token provided below. When invoking automation workflows, include this token in the `token` field under the `authentication` property.
 
 ```none
-fq5vf/ZmrjGiwmRHyzxL12iyg5eZZi6d+LK+Akpn4jU5Ukzj2FVl1tijU7smwL4y+IU+pCSB8gss+H1Mc+J11sI8NPpt13ECxNPegVby0jMW6T+DNDtcKffYT22AcqU0fFUXzzehO291g/7mLgGcPrM1Zjd+SyYCOC1am26KXP7uM+AR2XoL40Sn7tMOjlJ51K5vlTpnN4vAhZl+eJFmYqQYeEY0eBcJCc9w4/n0YgJFgLAG1HOp6+3dBgHf7QBYmbXRjqE5DMa9SivCtuNhxvaa4GeUoGRWBLzwb2WqNToqbmBs2ncekr4kgfD0w+g8ML7TKCSZJjMqyv3O0cSADut5GwmS3ZkZr/OLRR4ln+4=
+vrSdgliW5bWS4VrZbl2ignAzTMWIoAzrZFPn+9Nt0nVOK2ZtPUkBsu2sO3WPvjlRO3jiIE1hiU1jgXGNUMpx0Ix+6IKJpq9MjfmehB+DW0TpCINSasOqlMZNxbhAwyPpVm6DcXGUfMolMcO86lDJVua4VOhFvpR+4rByzvR2utBvhi2rIhLbWyTPC33IpZ5uGRtGMOa/lPlpj1Z2xKSvGWZhMYW08TkoIV77hHpMTEij4pnnae9Gvko2GgEiBokyumLbXxgx7ORcKJnoNZwNEsV9EsXczXK8AHJVf/GL65mNiulc5kcQcFmRYZeZL0M0qN4MyaFpOOKgLBkSakxe7ZSNWC9OKHDWUf7+ir/gz94=
 ```
 
 ---

--- a/src/G4.Services.Domain.V4/G4.Services.Domain.V4.csproj
+++ b/src/G4.Services.Domain.V4/G4.Services.Domain.V4.csproj
@@ -16,11 +16,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Api" Version="2026.7.13.48" />
+		<PackageReference Include="G4.Api" Version="2026.7.20.49" />
 		<PackageReference Include="G4.Plugins" Version="2026.7.11.70" />
-		<PackageReference Include="G4.Plugins.Common" Version="2026.7.12.133" />
-		<PackageReference Include="G4.Plugins.Ui" Version="2026.7.12.133" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+		<PackageReference Include="G4.Plugins.Common" Version="2026.7.19.135" />
+		<PackageReference Include="G4.Plugins.Ui" Version="2026.7.19.135" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
 	</ItemGroup>

--- a/src/G4.Services.Hub/wwwroot/js/global.js
+++ b/src/G4.Services.Hub/wwwroot/js/global.js
@@ -469,10 +469,16 @@ const setDefinition = (definition) => {
 		// Create a new step using the state machine factory and the retrieved manifest.
 		const step = StateMachineSteps.newG4Step(manifest, rule.pluginName);
 
-		// Assign the name of the rule's capabilities to the step if available.
+		// Compose the step label: keep the plugin's current name behaviour (its manifest name, or an
+		// explicit displayName override), then append the recorder-attached element name when present
+		// so recorded actions read as "<plugin> — <element>" without losing the plugin's own naming.
+		const baseName = rule?.capabilities?.displayName || step.name;
+		const elementName = rule?.capabilities?.elementName;
+		const composedName = elementName ? `${baseName} — ${elementName}` : baseName;
+
 		step.name = step?.pluginName?.toUpperCase() === 'MISSINGPLUGIN'
-			? `Missing Plugin (${rule?.capabilities?.displayName || step.name})`
-			: rule?.capabilities?.displayName || step.name;
+			? `Missing Plugin (${composedName})`
+			: composedName;
 
 		// Ensure that the rule has 'rules' and 'branches' properties.
 		rule.rules = rule.rules || [];

--- a/src/G4.Settings/G4.Settings.csproj
+++ b/src/G4.Settings/G4.Settings.csproj
@@ -34,16 +34,16 @@
 			 https://github.com/mbdavid/LiteDB/issues/1976#issuecomment-1968006775 -->
 		<PackageReference Include="G4.Converters" Version="2026.7.11.70" />
 		<PackageReference Include="LiteDB" Version="5.0.17" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Primitives" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Primitives" Version="10.0.10" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated G4.Api, G4.Plugins.Common, G4.Plugins.Ui, and Microsoft.AspNetCore.SignalR.Client package versions in G4.Services.Domain.V4.csproj
- Bumped Microsoft.Extensions.Configuration packages to 10.0.10 in G4.Settings.csproj
- Enhanced step naming in global.js for clearer action labels
- Updated README.md with new G4™ Hub API license token